### PR TITLE
Extra byte allocation and more changes in the string library

### DIFF
--- a/libcnet/io.c
+++ b/libcnet/io.c
@@ -192,9 +192,6 @@ string *cnet_read_until(void *ptr, char *delim, int len){
         die("read_until failed");
     }
 
-    if (total == 0)
-        return NULL;
-
     return res;
 }
 

--- a/libcnet/io.c
+++ b/libcnet/io.c
@@ -93,12 +93,13 @@ string *cnet_nread(void *ptr, int size)
     if (check_socket_type(io))
         return res;
 
-    int buf_size = DEFAULT_BUF_SIZE;
+    int buf_size = (DEFAULT_BUF_SIZE > size) ? size : DEFAULT_BUF_SIZE;
     char buf[buf_size];
 
     while(size >= 0 && (n = fread(buf, 1, buf_size, io->f)) > 0){
         cnet_strmerge_custom(res, buf, n);
         size -= n;
+        buf_size = (DEFAULT_BUF_SIZE > size) ? size : DEFAULT_BUF_SIZE;
     }
 
     if (ferror(io->f)){
@@ -134,19 +135,21 @@ string *cnet_read(void *ptr)
 
 }
 
-static int find_nl_index(char *buf, int n)
-{
-    for (int i =0; i < n-1; i++){
-        if(buf[i] == '\n' || (buf[i] == '\r' && buf[i+1] == '\n'))
-            return i+1;
-    }
+/* Deprecated */
+// static int find_nl_index(char *buf, int n)
+// {
+//     for (int i =0; i < n-1; i++){
+//         if(buf[i] == '\n' || (buf[i] == '\r' && buf[i+1] == '\n'))
+//             return i+1;
+//     }
 
-    if(buf[n-1] == '\n')
-        return n;
+//     if(buf[n-1] == '\n')
+//         return n;
 
-    return n+1;
+//     return n+1;
 
-}
+// }
+
 string *cnet_read_until(void *ptr, char *delim, int len){
     cnet_io *io = (cnet_io *) ptr;
     string *res = cnet_empty_str();

--- a/libcnet/io.c
+++ b/libcnet/io.c
@@ -61,7 +61,7 @@ static void cnet_strmerge_custom(string *s, char *buf, int len)
 {
     string temp = {NULL, buf, len};
 
-    return cnet_strmerge(s, &temp);
+    cnet_strmerge(s, &temp);
 
 }
 

--- a/libcnet/str.h
+++ b/libcnet/str.h
@@ -13,13 +13,13 @@ string *cnet_new_str(char *data, int length);
 
 string *cnet_new_str_nolen(char* data);
 
-void cnet_strcpy(string *dst, string *src);
+string *cnet_strcpy(string *dst, string *src);
 
 string *cnet_strassign(string *s);
 
 string *cnet_strcat(string *s1, string *s2);
 
-void cnet_strmerge(string *s1, string *s2);
+string *cnet_strmerge(string *s1, string *s2);
 
 string *cnet_strmult(string *s, int mult);
 

--- a/libcnet/str.h
+++ b/libcnet/str.h
@@ -4,7 +4,7 @@
 
 #define DEFAULT_LENGTH 20
 
-/*string * can be casted to char * if needed */ 
+/*string * can be casted to char * if needed */
 
 
 string *cnet_empty_str();
@@ -37,7 +37,9 @@ string *cnet_substring(string *s, int start, int end);
 
 string *cnet_reverse_str(string *s);
 
-void cpy_str(string *src, char *dst);
+// Bruk: This is deprecated because of the new one more extra byte allocation
+// That extra byte is used to store a null terminator on demand.
+/* void cpy_str(string *src, char *dst); */
 
 int cnet_str_atoi(string *s);
 

--- a/libcnet/string.c
+++ b/libcnet/string.c
@@ -82,7 +82,7 @@ string *cnet_new_str_nolen(char* data)
  * string s2 = "Hell0";
  * s1 = s2;
  */
-void cnet_strcpy(string *dst, string *src)
+string *cnet_strcpy(string *dst, string *src)
 {
 	if (!dst || !src)
 		die("Error: Null Pointer\n");
@@ -94,6 +94,8 @@ void cnet_strcpy(string *dst, string *src)
 	dst->data = (char *) mem_alloc(src->length + 1);
 
 	memcpy(dst->data, src->data, src->length);
+
+	return dst;
 }
 
 /* operator eg.
@@ -126,7 +128,7 @@ string *cnet_strcat(string *s1, string *s2)
 }
 
 /* Operator += */
-void cnet_strmerge(string *s1, string *s2)
+string *cnet_strmerge(string *s1, string *s2)
 {
 	if (!s1 || !s2)
 		die("Error: Null Pointer\n");
@@ -140,6 +142,8 @@ void cnet_strmerge(string *s1, string *s2)
 
 	s1->length += s2->length;
 	s1->data    = temp_data;
+
+	return s1;
 }
 
 /* Operator * */

--- a/libcnet/string.c
+++ b/libcnet/string.c
@@ -170,6 +170,14 @@ int cnet_strcmp(string *s1, string *s2)
 	if (!s1 && !s2)
 		return 0;
 
+	// Need to check s1 || s2 is not an empty string
+	//  before null-terminating
+	if (!s1->data && !s2->data)
+		return 0;
+	
+	if (!s1->data || !s2->data)
+		return -1;
+
 	// null-terminator is stored at the last extra byte alloated
 	s1->data[s1->length] = '\0';
 	s2->data[s2->length] = '\0';
@@ -299,6 +307,9 @@ int cnet_find_char(string *s, char c)
 
 void print_cnet_str(string *s)
 {
+	if (!s || !s->data)
+		return;
+
 	s->data[s->length] = '\0';
 	printf("%s", s->data);
 

--- a/libcnet/utils.h
+++ b/libcnet/utils.h
@@ -1,16 +1,16 @@
 #ifndef _UTILS_H_
 #define _UTILS_H_
 
-/* strings */ 
+/* strings */
 struct string {
-	void (*cnet_free) (void *str);
+	void (*cnet_free) (void *);
 	char *data;
 	int length;
 };
 
 typedef struct string string;
 
-/* files */ 
+/* files */
 struct cnet_file {
 	void (*cnet_free) (void *f);
 	FILE *f;
@@ -39,7 +39,7 @@ struct prot_type {
 
 typedef struct prot_type prot_type;
 
-/* for casting purposes*/ 
+/* for casting purposes*/
 struct cnet_io {
 	void (*cnet_free) (void *ptr);
 	FILE *f;

--- a/tests/stdlib/test7.c
+++ b/tests/stdlib/test7.c
@@ -7,7 +7,7 @@
 
 int main()
 {
-	int port 	 = 8000;
+	int port 	 = 10000;
 	char *host = "localhost";
 	string *host_str = cnet_new_str_nolen(host);
 
@@ -17,10 +17,12 @@ int main()
 		goto failed;
 
 	printf("Connected to host %s\n", host);
+	string *s;
+	while ((s = cnet_readln(client_sock))) {
+		printf("Length: %d, String: ", s->length);
+		print_cnet_str(s);
+	}
 
-	string *s = cnet_readln(client_sock);
-	printf("%s", "Read from socket: ");
-	print_cnet_str(s);
 	cnet_free(s);
 
 failed:


### PR DESCRIPTION
- Allocate an extra byte at the end of all our strings. From the user's perspective this does not exist. But from our side we can store a null terminator at that extra byte and use it for some beneficial cases. 
- Implement `cnet_read_until`. It's a generic form of `read_ln` but instead of always looking for the `\n` it reads a file until it reads the `delimiter`.  