### PR TITLE
create new libcnet-main.a library to prevent linking error in stdlib …

### DIFF
--- a/ccnet
+++ b/ccnet
@@ -10,7 +10,7 @@ import shutil
 CC		= "gcc"			# C compiler
 LLC		= "llc"			# LLVM compiler
 CNET	= "cnet.native" # CNET compiler
-LIBCNET = "libcnet/libcnet.a"
+LIBCNET = "libcnet/libcnet-main.a"
 
 USAGEMSG  = """USAGE: {} -[t|a|s|l|b] source """.format(sys.argv[0])
 

--- a/libcnet/Makefile
+++ b/libcnet/Makefile
@@ -4,6 +4,10 @@ OBJS := string.o utils.o io.o
 DEPENDS := string.h utils.h io.h
 
 # clean up object files cause we don't need them
+libcnet-main.a: stdlib driver.o
+	ar -cq libcnet-main.a *.o
+	rm -f *.o
+
 libcnet.a: stdlib
 	ar -cq libcnet.a *.o
 	rm -f *.o

--- a/libcnet/driver.c
+++ b/libcnet/driver.c
@@ -1,0 +1,35 @@
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <fcntl.h>
+#include "utils.h"
+#include "str.h"
+#include "io.h"
+
+cnet_array *parse_main_args(int argc, char **argv)
+{
+	cnet_array *args = cnet_init_array(8, String, argc, 0);
+	string **data = (string **)args->data;
+	for(int i = 0 ; i < argc; i++){
+		string *new_str = cnet_new_str_nolen(argv[i]);
+		cnet_strcpy(data[i], new_str);
+		cnet_free(new_str);
+	}
+
+	return args;
+}
+
+int main(int argc, char **argv)
+{
+	cnet_array *string_arr = parse_main_args(argc-1, &argv[1]);
+	int ret = user_main(string_arr);
+	cnet_free(string_arr);
+	return ret;
+}

--- a/libcnet/io.h
+++ b/libcnet/io.h
@@ -16,7 +16,7 @@
 #define LISTEN 0
 #define CONNECT 1
 
-cnet_file *cnet_open_file(string *filename, string *mode);
+cnet_file *user_fopen(string *filename, string *mode);
 
 cnet_socket *cnet_listen_socket(int domain, int type, unsigned short port);
 

--- a/libcnet/string.c
+++ b/libcnet/string.c
@@ -78,7 +78,7 @@ string *cnet_new_str_nolen(char* data)
 {
 	int len = strlen(data);
 	char *new_data = malloc(len);
-	strncpy(new_data, data, len);
+	memcpy(new_data, data, len);
 	return cnet_new_str(data, len);
 }
 

--- a/libcnet/utils.c
+++ b/libcnet/utils.c
@@ -67,7 +67,7 @@ cnet_array *cnet_init_array(int sizei_t, int type_t, int len, int arr_lit_len, .
 	int n;
 	unsigned long ptr;
 	double d;
-	
+
 
 	for (int i = 0; i<(arr_lit_len*sizei_t); i+=sizei_t){
 		if (sizei_t == 1){
@@ -129,25 +129,4 @@ int alength(void *ptr)
 	cnet_array *arr = (cnet_array *)ptr;
 
 	return arr->length;
-}
-
-cnet_array *parse_main_args(int argc, char **argv)
-{
-	cnet_array *args = cnet_init_array(8, String, argc, 0);
-	string **data = (string **)args->data;
-	for(int i = 0 ; i < argc; i++){
-		string *new_str = cnet_new_str_nolen(argv[i]);
-		cnet_strcpy(data[i], new_str);
-		cnet_free(new_str);
-	}
-
-	return args;
-}
-
-int main(int argc, char **argv)
-{
-	cnet_array *string_arr = parse_main_args(argc-1, &argv[1]);
-	int ret = user_main(string_arr);
-	cnet_free(string_arr);
-	return ret;
 }

--- a/libcnet/utils.h
+++ b/libcnet/utils.h
@@ -66,5 +66,7 @@ void *mem_alloc(int size);
 
 void cnet_free(void *s);
 
+cnet_array *cnet_init_array(int sizei_t, int type_t, int len, int arr_lit_len, ...);
+
 int user_main(cnet_array *args);
 #endif

--- a/tests/stdlib/Makefile
+++ b/tests/stdlib/Makefile
@@ -10,7 +10,7 @@ OBJS := libcnet.a
 OBJS := $(addprefix $(LIB_DIR)/, $(OBJS));
 DEPENDS := string.h utils.h io.h
 DEPENDS := $(addprefix $(LIB_DIR)/, $(DEPENDS));
-CTESTS := cnet_test1 cnet_test2 cnet_test3 cnet_test4 cnet_test5 cnet_test6 cnet_test7 cnet_test8 cnet_test9
+CTESTS := cnet_test1 cnet_test2 cnet_test3 cnet_test4 cnet_test5 cnet_test6 cnet_test7 cnet_test8 cnet_test9 cnet_test10
 
 stdlib_tests: clean stdlib $(CTESTS)
 

--- a/tests/stdlib/test3.c
+++ b/tests/stdlib/test3.c
@@ -13,7 +13,7 @@ int main()
 	cnet_io io = {NULL, sdout, CNET_FILE};
 	string *filename = cnet_new_str(fname, strlen(fname));
 	string *mode	 = cnet_new_str("a+", strlen("a+"));
-	cnet_file *file  = cnet_open_file(filename, mode);
+	cnet_file *file  = user_fopen(filename, mode);
 
 	string *s = cnet_new_str(line, fread(line, 1, 18, file->f));
 	writeln(&io, s);

--- a/tests/stdlib/test9.c
+++ b/tests/stdlib/test9.c
@@ -7,7 +7,7 @@
 
 int main(){
 
-    cnet_file *file = cnet_open_file(cnet_new_str_nolen("file.txt"), cnet_new_str_nolen("rb"));
+    cnet_file *file = user_fopen(cnet_new_str_nolen("file.txt"), cnet_new_str_nolen("rb"));
     string *newline = cnet_new_str_nolen("\n");
 
 


### PR DESCRIPTION
- Remove definition of main from `libcnet.a` 
- Create a driver `libcnet-main.a` library that has the main function. (Technically library archives aren't supposed to define a main function but it's a quick hack. 
- 
